### PR TITLE
Adds "autoParseDates" option (closes #67)

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,5 +1,6 @@
 export interface IImportOptions {
   dates?: string[]
+  autoParseDates?: boolean
   geos?: string[]
   refs?: string[]
 }
@@ -28,6 +29,14 @@ const isObject = (test: any) => {
 }
 
 /**
+ * Check if the parameter is an Object
+ * @param test
+ */
+const isArray = (test: any) => {
+  return Array.isArray(test)
+}
+
+/**
  * Traverse given data, until there is no sub node anymore
  * Executes the callback function for every sub node found
  * @param data
@@ -35,7 +44,7 @@ const isObject = (test: any) => {
  */
 export const traverseObjects = (data: any, callback: Function) => {
   for (const [key, value] of Object.entries(data)) {
-    if (!isObject(value)) {
+    if (!isObject(value) && !isArray(value)) {
       continue
     }
 
@@ -47,4 +56,17 @@ export const traverseObjects = (data: any, callback: Function) => {
 
     traverseObjects(data[key], callback)
   }
+}
+
+export function parseAndConvertDates(data: object) {
+  traverseObjects(data, value => {
+    const isTimeStamp =
+      typeof value === "object" &&
+      value.hasOwnProperty("_seconds") &&
+      value.hasOwnProperty("_nanoseconds");
+    if (isTimeStamp) {
+      return makeTime(value);
+    }
+    return null;
+  })
 }

--- a/src/import.ts
+++ b/src/import.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import { v1 as uuidv1 } from 'uuid'
 import * as admin from 'firebase-admin'
-import { makeTime, traverseObjects, IImportOptions } from './helper'
+import { makeTime, traverseObjects, IImportOptions, parseAndConvertDates } from './helper'
 
 /**
  * Restore data to firestore
@@ -151,6 +151,10 @@ const startUpdating = (
         })
       }
     })
+  }
+
+  if (options.autoParseDates) {
+    parseAndConvertDates(data);
   }
 
   // reference key

--- a/test/firestore.spec.ts
+++ b/test/firestore.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import request from 'request-promise';
 import * as firestoreService from '../dist';
+import { parseAndConvertDates } from '../src/helper';
 import { serviceAccount } from './serviceAccount';
 
 const app = firestoreService.initializeApp(
@@ -97,5 +98,75 @@ describe('initializeApp function test', () => {
     } catch (error) {
       console.log(error);
     }
+  });
+
+  it('Test auto parse dates option - simple', async () => {
+    const data = {
+      date: {
+        _seconds: 1534046400,
+        _nanoseconds: 0,
+      },
+    };
+    parseAndConvertDates(data);
+    expect(data.date).to.be.an.instanceOf(Date);
+  });
+
+  it('Test auto parse dates option - nested', async () => {
+    const data = {
+      date: {
+        _seconds: 1534046400,
+        _nanoseconds: 0,
+      },
+      obj: {
+        anotherObj: {
+          date: {
+            _seconds: 1534046400,
+            _nanoseconds: 0,
+          }
+        }
+      },
+    };
+    parseAndConvertDates(data);
+    expect(data.date).to.be.an.instanceOf(Date);
+    expect(data.obj.anotherObj.date).to.be.an.instanceOf(Date);
+  });
+
+  it('Test auto parse dates option - nested arrays', async () => {
+    const data = {
+      arr: [
+        {
+          _seconds: 1534046400,
+          _nanoseconds: 0,
+        }
+      ],
+    };
+    parseAndConvertDates(data);
+    expect(data.arr[0]).to.be.an.instanceOf(Date);
+  });
+
+  it('Test auto parse dates option - nested array objects', async () => {
+    const data = {
+      arr: [
+        {
+          obj: {
+            date: {
+              _seconds: 1534046400,
+              _nanoseconds: 0,
+            },
+          },
+        },
+        {
+          obj: {
+            date: {
+              _seconds: 1534046400,
+              _nanoseconds: 0,
+            },
+          },
+        },
+      ],
+    };
+    parseAndConvertDates(data);
+    expect(data.arr[0].obj.date).to.be.an.instanceOf(Date);
+    expect(data.arr[1].obj.date).to.be.an.instanceOf(Date);
   });
 });


### PR DESCRIPTION
This PR adds the ability for dates to be automatically parsed when using the `restore` function.

**Test This PR**
1. `yarn build`
2. `yarn test`

**Test in Script**
``` js
await firestoreService.restore(backupData, {autoParseDates: true});
```

Closes #67 