### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ const firestoreService = require('firestore-export-import');
 const serviceAccount = require('./serviceAccountKey.json');
 
 // Initiate Firebase App
-// appName is optional, you can omit it.
-const appName = '[DEFAULT]';
-firestoreService.initializeApp(serviceAccount, databaseURL, appName);
+firestoreService.initializeApp(serviceAccount);
 
 // Start exporting your data
 firestoreService
@@ -115,9 +113,7 @@ const firestoreService = require('firestore-export-import');
 const serviceAccount = require('./serviceAccountKey.json');
 
 // Initiate Firebase App
-// appName is optional, you can obmit it.
-const appName = '[DEFAULT]';
-firestoreService.initializeApp(serviceAccount, databaseURL, appName);
+firestoreService.initializeApp(serviceAccount);
 
 // Start importing your data
 // The array of date, location and reference fields are optional


### PR DESCRIPTION
As mentioned in the discussion (https://github.com/dalenguyen/firestore-backup-restore/discussions/73) this code worked for me to get the sample working.
First time proposing a change. I hope this is the correct way to do it.

I also changed the initializeApp part in line 116. I think it needs to be done there as well, but I didn´t test that 'For local JSON' part of the code samples.

-> I´m not really sure how firestoreService gets access to the 'databaseURL' now(?). I guess the 'project_id' from the serviceAccountKey.json is used. But please double-check if that is correct.

I got this error by running 'yarn start' when using the default readme example:
```
yarn run v1.22.5
$ node index.js
C:\[PATHTOPROJECT]\node_modules\firebase-admin\lib\firebase-namespace.js:101
            throw new error_1.FirebaseAppError(error_1.AppErrorCodes.NO_APP, errorMessage);
            ^

FirebaseAppError: The default Firebase app does not exist. Make sure you call initializeApp() before using any of the Firebase services.
    at FirebaseAppError.FirebaseError [as constructor] (C:\[PATHTOPROJECT]\node_modules\firebase-admin\lib\utils\error.js:43:28)
    at FirebaseAppError.PrefixedFirebaseError [as constructor] (C:\[PATHTOPROJECT]\node_modules\firebase-admin\lib\utils\error.js:89:28)
    at new FirebaseAppError (C:\[PATHTOPROJECT]\node_modules\firebase-admin\lib\utils\error.js:124:28)
    at FirebaseNamespaceInternals.app (C:\[PATHTOPROJECT]\node_modules\firebase-admin\lib\firebase-namespace.js:101:19)
    at FirebaseNamespace.app (C:\[PATHTOPROJECT]\node_modules\firebase-admin\lib\firebase-namespace.js:433:30)
    at FirebaseNamespace.ensureApp (C:\[PATHTOPROJECT]\node_modules\firebase-admin\lib\firebase-namespace.js:449:24)
    at FirebaseNamespace.fn (C:\[PATHTOPROJECT]\node_modules\firebase-admin\lib\firebase-namespace.js:308:30)
    at Object.exports.initializeApp (C:\[PATHTOPROJECT]\node_modules\firestore-export-import\dist\index.js:2:183)
    at Object.<anonymous> (C:\[PATHTOPROJECT]\index.js:11:18)
    at Module._compile (internal/modules/cjs/loader.js:1137:30) {
  errorInfo: {
    code: 'app/no-app',
    message: 'The default Firebase app does not exist. Make sure you call initializeApp() before using any of the Firebase services.'
  },
  codePrefix: 'app'
}
error Command failed with exit code 1.
```