### PR TITLE
Adds "autoParseGeos" option

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -5,6 +5,7 @@ export interface IImportOptions {
   dates?: string[]
   autoParseDates?: boolean
   geos?: string[]
+  autoParseGeos?: boolean
   refs?: string[]
   showLogs?: boolean
 }
@@ -102,5 +103,18 @@ export const parseAndConvertDates = (data: object) => {
       return makeTime(value)
     }
     return null
+  })
+}
+
+export function parseAndConvertGeos(data: object) {
+  traverseObjects(data, value => {
+    const isGeoPoint =
+      typeof value === "object" &&
+      value.hasOwnProperty("_latitude") &&
+      value.hasOwnProperty("_longitude");
+    if (isGeoPoint) {
+      return makeGeoPoint(value);
+    }
+    return null;
   })
 }

--- a/src/import.ts
+++ b/src/import.ts
@@ -7,6 +7,7 @@ import {
   IImportOptions,
   parseAndConvertDates,
   makeGeoPoint,
+  parseAndConvertGeos,
 } from './helper'
 
 /**
@@ -198,6 +199,10 @@ const startUpdating = (
         })
       }
     })
+  }
+
+  if (options.autoParseGeos) {
+    parseAndConvertGeos(data)
   }
 
   return new Promise((resolve, reject) => {

--- a/test/firestore.spec.ts
+++ b/test/firestore.spec.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai'
 import request from 'request-promise'
-import { parseAndConvertDates } from '../src/helper'
+import { parseAndConvertDates, parseAndConvertGeos } from '../src/helper'
 import { serviceAccount } from './serviceAccount'
 import { backup, backups, initializeApp, restore } from '../dist'
+import { firestore } from 'firebase-admin'
 // import { backup, backups, initializeApp, restore } from '../package/dist'
 
 const app = initializeApp(serviceAccount)
@@ -214,5 +215,75 @@ describe('initializeApp function test', () => {
     parseAndConvertDates(data)
     expect(data.arr[0].obj.date).to.be.an.instanceOf(Date)
     expect(data.arr[1].obj.date).to.be.an.instanceOf(Date)
+  })
+
+  it('Test auto parse geos option - simple', async () => {
+    const data = {
+      location: {
+        _latitude: 35.687498354666516,
+        _longitude: 139.44018328905466,
+      },
+    }
+    parseAndConvertGeos(data)
+    expect(data.location).to.be.an.instanceOf(firestore.GeoPoint)
+  })
+
+  it('Test auto parse geos option - nested', async () => {
+    const data = {
+      location: {
+        _latitude: 35.687498354666516,
+        _longitude: 139.44018328905466,
+      },
+      obj: {
+        anotherObj: {
+          location: {
+            _latitude: 35.687498354666516,
+            _longitude: 139.44018328905466,
+          },
+        },
+      },
+    }
+    parseAndConvertGeos(data)
+    expect(data.location).to.be.an.instanceOf(firestore.GeoPoint)
+    expect(data.obj.anotherObj.location).to.be.an.instanceOf(firestore.GeoPoint)
+  })
+
+  it('Test auto parse geos option - nested arrays', async () => {
+    const data = {
+      arr: [
+        {
+          _latitude: 35.687498354666516,
+          _longitude: 139.44018328905466,
+        },
+      ],
+    }
+    parseAndConvertGeos(data)
+    expect(data.arr[0]).to.be.an.instanceOf(firestore.GeoPoint)
+  })
+
+  it('Test auto parse geos option - nested array objects', async () => {
+    const data = {
+      arr: [
+        {
+          obj: {
+            location: {
+              _latitude: 35.687498354666516,
+              _longitude: 139.44018328905466,
+            },
+          },
+        },
+        {
+          obj: {
+            location: {
+              _latitude: 35.687498354666516,
+              _longitude: 139.44018328905466,
+            },
+          },
+        },
+      ],
+    }
+    parseAndConvertGeos(data)
+    expect(data.arr[0].obj.location).to.be.an.instanceOf(firestore.GeoPoint)
+    expect(data.arr[1].obj.location).to.be.an.instanceOf(firestore.GeoPoint)
   })
 })


### PR DESCRIPTION
This PR adds the ability for geos to be automatically parsed when using the restore function. In the same way as the autoParseDates option https://github.com/dalenguyen/firestore-backup-restore/pull/68