### PR TITLE
prevent runtime error when exported document has only sub-collections

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -56,7 +56,8 @@ export const backupFromDoc = async <T>(
     for (const doc of docs) {
       const subCollections = await doc.ref.listCollections()
 
-      data[collectionName][doc.id] = doc.data()
+      const d = doc.data()
+      data[collectionName][doc.id] = d ? d : {}
 
       if (options?.refs) {
         for (const refKey of options?.refs) {


### PR DESCRIPTION
This is a simple fix to avoid running into a runtime error when the exported document only has subcollections