### PR TITLE
fix: ignore queryCollection option when exporting sub-collection data

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -142,7 +142,10 @@ export const backUpDocRef = async <T>(
 
   if (subCollections.length > 0) {
     data['subCollection'] = {}
-    const {queryCollection, ...subColOptions} = options;
+    const subColOptions = {...options};
+    if (subColOptions?.queryCollection) {
+      delete subColOptions.queryCollection;
+    }
     for (const subCol of subCollections) {
       const subColData = await backupService<object>(
         `${collectionPath}/${doc.id}/${subCol.id}`,

--- a/src/export.ts
+++ b/src/export.ts
@@ -142,10 +142,11 @@ export const backUpDocRef = async <T>(
 
   if (subCollections.length > 0) {
     data['subCollection'] = {}
+    const {queryCollection, ...subColOptions} = options;
     for (const subCol of subCollections) {
       const subColData = await backupService<object>(
         `${collectionPath}/${doc.id}/${subCol.id}`,
-        options
+        subColOptions
       )
 
       data['subCollection'] = {


### PR DESCRIPTION
Bugfix to close #147 