### PR TITLE
fix: preserve nanoseconds, fix nested type conversion, add batch writes (v1.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Restore now uses Firestore batch writes (500 docs/batch) — dramatically faster on large collections (#18)
 - Simplified import internals: replaced recursive sequential writes with `collectWrites` + batched commit
 - `restoreService` modernized to use `fs.promises` (async/await instead of callbacks)
+- `initializeFirebaseApp` now correctly handles multiple named apps — previously always returned the first initialized app regardless of the `name` parameter (#153)
+- `showLogs` option is now supported during export (`backup`, `backupFromDoc`, `backups`) in addition to restore (#121)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@
 > - :nail_care: [Polish]
 
 ---
+## [1.7.0] - 2026-07-13
+
+#### - :bug: [Bug Fix]
+
+- Timestamps now preserve nanosecond precision on restore — `makeTime` returns `Firestore.Timestamp` instead of `Date` (#136)
+- Fixed `makeGeoPoint` incorrectly returning `null` for coordinates equal to `0`
+- Dates and GeoPoints nested inside arrays of objects are now correctly converted during restore (#50, #83)
+- Refs nested inside arrays of objects are now correctly resolved during restore
+
+#### - :rocket: [New Feature]
+
+- `clearCollection` import option: deletes the target collection(s) before restoring, enabling clean full restores (#19)
+- `includeSubcollections` export option: set to `false` to skip subcollection traversal, reducing export time on large datasets (#103)
+
+#### - :nail_care: [Polish]
+
+- Restore now uses Firestore batch writes (500 docs/batch) — dramatically faster on large collections (#18)
+- Simplified import internals: replaced recursive sequential writes with `collectWrites` + batched commit
+- `restoreService` modernized to use `fs.promises` (async/await instead of callbacks)
+
+---
+
 ## [1.6.0] - 2025-02-14
 
 #### - :nail_care: [Polish]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-export-import",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "NPM package for backup and restore Firebase Firestore",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/export.ts
+++ b/src/export.ts
@@ -20,6 +20,10 @@ export const getAllCollectionsService = async <T>(
     snap.forEach((collection) => paths.push(collection.path))
   }
 
+  if (options?.showLogs) {
+    console.log(`Starting backup of ${paths.length} collection(s): ${paths.join(', ')}`)
+  }
+
   // fetch in parallel
   const promises: Promise<T>[] = paths.map((path) =>
     backupService<T>(db, path, options)
@@ -96,6 +100,10 @@ export const backupFromDocService = async <T>(
           }
         }
       }
+    }
+
+    if (options?.showLogs) {
+      console.log(`Backed up document "${documentName}" from "${collectionName}"`)
     }
 
     return data as T
@@ -205,6 +213,10 @@ export const backupService = async <T>(
     promiseValues.forEach((dataMap) => {
       data[collectionName] = Object.assign(data[collectionName], dataMap)
     })
+
+    if (options?.showLogs) {
+      console.log(`Backed up ${docs.length} document(s) from "${collectionName}"`)
+    }
 
     return data as T
   } catch (error) {

--- a/src/export.ts
+++ b/src/export.ts
@@ -80,7 +80,7 @@ export const backupFromDocService = async <T>(
         }
       }
 
-      if (subCollections.length > 0) {
+      if (subCollections.length > 0 && options?.includeSubcollections !== false) {
         data[collectionName][doc.id]['subCollection'] = {}
 
         for (const subCol of subCollections) {
@@ -144,7 +144,7 @@ export const backUpDocRef = async <T>(
     }
   }
 
-  if (subCollections.length > 0) {
+  if (subCollections.length > 0 && options?.includeSubcollections !== false) {
     data['subCollection'] = {}
     const subColOptions = { ...options }
     if (subColOptions?.queryCollection) {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -14,6 +14,7 @@ export interface IExportOptions {
   docsFromEachCollection?: number
   refs?: string[]
   includeSubcollections?: boolean
+  showLogs?: boolean
   queryCollection?: (
     ref: FirebaseFirestore.CollectionReference
   ) => Promise<FirebaseFirestore.QuerySnapshot>

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,4 +1,4 @@
-import { GeoPoint } from 'firebase-admin/firestore'
+import { GeoPoint, Timestamp } from 'firebase-admin/firestore'
 
 export interface IImportOptions {
   dates?: string[]
@@ -7,11 +7,13 @@ export interface IImportOptions {
   autoParseGeos?: boolean
   refs?: string[]
   showLogs?: boolean
+  clearCollection?: boolean
 }
 
 export interface IExportOptions {
   docsFromEachCollection?: number
   refs?: string[]
+  includeSubcollections?: boolean
   queryCollection?: (
     ref: FirebaseFirestore.CollectionReference
   ) => Promise<FirebaseFirestore.QuerySnapshot>
@@ -21,26 +23,20 @@ export const makeGeoPoint = (geoValues: {
   _latitude: number
   _longitude: number
 }) => {
-  if (!geoValues._latitude || !geoValues._longitude) {
+  if (geoValues?._latitude == null || geoValues?._longitude == null) {
     return null
   }
-
   return new GeoPoint(geoValues._latitude, geoValues._longitude)
 }
-
-/**
- * Convert time array in a Date object
- * @param firebaseTimestamp
- */
 
 export const makeTime = (firebaseTimestamp: {
   _seconds: number
   _nanoseconds: number
-}): Date | null => {
-  if (!firebaseTimestamp || !firebaseTimestamp._seconds) {
+}): Timestamp | null => {
+  if (!firebaseTimestamp || firebaseTimestamp._seconds == null) {
     return null
   }
-  return new Date(firebaseTimestamp._seconds * 1000)
+  return new Timestamp(firebaseTimestamp._seconds, firebaseTimestamp._nanoseconds ?? 0)
 }
 
 export const getPath = (obj?: { path?: string }) => {
@@ -116,4 +112,34 @@ export function parseAndConvertGeos(data: object) {
     }
     return null
   })
+}
+
+/**
+ * Traverse a nested object/array following a dot-split key path,
+ * applying fn at the leaf. Arrays at any level are iterated automatically.
+ */
+export const applyToPath = (
+  data: any,
+  keys: string[],
+  fn: (val: any) => any
+): void => {
+  if (!keys.length) return
+
+  if (Array.isArray(data)) {
+    data.forEach((item) => applyToPath(item, keys, fn))
+    return
+  }
+
+  if (
+    data == null ||
+    data.constructor !== Object ||
+    !Object.prototype.hasOwnProperty.call(data, keys[0])
+  )
+    return
+
+  if (keys.length === 1) {
+    data[keys[0]] = fn(data[keys[0]])
+  } else {
+    applyToPath(data[keys[0]], keys.slice(1), fn)
+  }
 }

--- a/src/import.ts
+++ b/src/import.ts
@@ -10,11 +10,6 @@ import {
   parseAndConvertGeos,
 } from './helper.js'
 
-type WriteOp = {
-  ref: FirebaseFirestore.DocumentReference
-  data: Record<string, any>
-}
-
 const BATCH_SIZE = 500
 
 const prepareData = (
@@ -57,47 +52,76 @@ const prepareData = (
   }
 }
 
-const collectWrites = (
+const createBatchWriter = (db: Firestore, options: IImportOptions) => {
+  let batch = db.batch()
+  let pendingWrites = 0
+  let committedWrites = 0
+
+  const commit = async (): Promise<void> => {
+    if (!pendingWrites) return
+
+    await batch.commit()
+    committedWrites += pendingWrites
+    if (options.showLogs) {
+      console.log(`Committed ${pendingWrites} documents (${committedWrites} total)`)
+    }
+    batch = db.batch()
+    pendingWrites = 0
+  }
+
+  return {
+    set: async (ref: FirebaseFirestore.DocumentReference, data: Record<string, any>) => {
+      batch.set(ref, data)
+      pendingWrites += 1
+      if (pendingWrites === BATCH_SIZE) {
+        await commit()
+      }
+    },
+    commit,
+  }
+}
+
+const collectWrites = async (
   db: Firestore,
   dataObj: Record<string, any>,
   options: IImportOptions,
-  writes: WriteOp[]
-): void => {
+  writer: ReturnType<typeof createBatchWriter>
+): Promise<void> => {
   for (const collectionName of Object.keys(dataObj)) {
     const collectionData = dataObj[collectionName]
     const isArr = Array.isArray(collectionData)
 
-    const processDoc = (docId: string, docValue: any): void => {
+    const processDoc = async (docId: string, docValue: any): Promise<void> => {
       const rawData = { ...docValue }
       const subCollections = rawData.subCollection as Record<string, any> | undefined
       delete rawData.subCollection
 
       prepareData(db, rawData, options)
-      writes.push({ ref: db.collection(collectionName).doc(docId), data: rawData })
+      await writer.set(db.collection(collectionName).doc(docId), rawData)
 
       if (subCollections) {
         if (isArr) {
           for (const subIndex of Object.keys(subCollections)) {
-            collectWrites(
+            await collectWrites(
               db,
               { [`${collectionName}/${docId}/${subIndex}`]: subCollections[subIndex] },
               options,
-              writes
+              writer
             )
           }
         } else {
-          collectWrites(db, subCollections, options, writes)
+          await collectWrites(db, subCollections, options, writer)
         }
       }
     }
 
     if (isArr) {
       for (const docValue of collectionData) {
-        processDoc(uuidv1(), docValue)
+        await processDoc(uuidv1(), docValue)
       }
     } else {
       for (const [docId, docValue] of Object.entries(collectionData)) {
-        processDoc(docId, docValue)
+        await processDoc(docId, docValue)
       }
     }
   }
@@ -114,18 +138,9 @@ const updateCollection = async (
     }
   }
 
-  const writes: WriteOp[] = []
-  collectWrites(db, dataObj, options, writes)
-
-  for (let i = 0; i < writes.length; i += BATCH_SIZE) {
-    const batch = db.batch()
-    writes.slice(i, i + BATCH_SIZE).forEach(({ ref, data }) => batch.set(ref, data))
-    await batch.commit()
-    if (options.showLogs) {
-      const committed = Math.min(BATCH_SIZE, writes.length - i)
-      console.log(`Committed ${committed} documents (${i + committed}/${writes.length} total)`)
-    }
-  }
+  const writer = createBatchWriter(db, options)
+  await collectWrites(db, dataObj, options, writer)
+  await writer.commit()
 }
 
 export const restoreService = async (
@@ -142,6 +157,8 @@ export const restoreService = async (
     await updateCollection(db, dataObj, options)
     return { status: true, message: 'Collection successfully imported!' }
   } catch (error) {
-    throw { status: false, message: (error as Error).message }
+    const restoreError = new Error((error as Error).message)
+    ;(restoreError as Error & { status: boolean }).status = false
+    throw restoreError
   }
 }

--- a/src/import.ts
+++ b/src/import.ts
@@ -2,266 +2,146 @@ import type { Firestore } from 'firebase-admin/firestore'
 import fs from 'fs'
 import { v1 as uuidv1 } from 'uuid'
 import {
+  applyToPath,
   makeTime,
-  traverseObjects,
   IImportOptions,
   parseAndConvertDates,
   makeGeoPoint,
   parseAndConvertGeos,
 } from './helper.js'
 
-/**
- * Restore data to firestore
- *
- * @param {string} fileName
- * @param {IImportOptions} options
- */
-export const restoreService = (
-  db: Firestore,
-  fileName: string | Object,
-  options: IImportOptions
-): Promise<{ status: boolean; message: string }> => {
-  return new Promise<{ status: boolean; message: string }>(
-    (resolve, reject) => {
-      if (typeof fileName === 'object') {
-        let dataObj = fileName
-
-        updateCollection(db, dataObj, options)
-          .then(() => {
-            resolve({
-              status: true,
-              message: 'Collection successfully imported!',
-            })
-          })
-          .catch((error) => {
-            reject({ status: false, message: error.message })
-          })
-      } else {
-        fs.readFile(fileName, 'utf8', function (err, data) {
-          if (err) {
-            console.log(err)
-            reject({ status: false, message: err.message })
-          }
-
-          // Turn string from file to an Array
-          let dataObj = JSON.parse(data)
-
-          updateCollection(db, dataObj, options)
-            .then(() => {
-              resolve({
-                status: true,
-                message: 'Collection successfully imported!',
-              })
-            })
-            .catch((error) => {
-              reject({ status: false, message: error.message })
-            })
-        })
-      }
-    }
-  )
+type WriteOp = {
+  ref: FirebaseFirestore.DocumentReference
+  data: Record<string, any>
 }
 
-/**
- * Update data to firestore
- *
- * @param {any} db
- * @param {object} dataObj
- * @param {IImportOptions} options
- */
-const updateCollection = async (
+const BATCH_SIZE = 500
+
+const prepareData = (
   db: Firestore,
-  dataObj: object,
-  options: IImportOptions = {}
-) => {
-  for (const index in dataObj) {
-    let collectionName = index
-    for (const doc in dataObj[index]) {
-      if (dataObj[index].hasOwnProperty(doc)) {
-        // assign document id for array type
-        let docId = Array.isArray(dataObj[index]) ? uuidv1() : doc
-        if (!Array.isArray(dataObj[index])) {
-          const subCollections = dataObj[index][docId]['subCollection']
-          delete dataObj[index][doc]['subCollection']
-          try {
-            await startUpdating(
-              db,
-              collectionName,
-              docId,
-              dataObj[index][doc],
-              options
-            )
-          } catch (error) {
-            console.error(error)
-          }
-
-          if (subCollections) {
-            await updateCollection(db, subCollections, options)
-          }
-        } else {
-          const subCollections = dataObj[index][doc]['subCollection']
-
-          delete dataObj[index][doc]['subCollection']
-
-          await startUpdating(
-            db,
-            collectionName,
-            docId,
-            dataObj[index][doc],
-            options
-          )
-
-          if (subCollections) {
-            for (const subIndex in subCollections) {
-              const revivedSubCollection = {}
-              const subCollectionPath = `${collectionName}/${docId}/${subIndex}`
-              revivedSubCollection[subCollectionPath] = subCollections[subIndex]
-              await updateCollection(db, revivedSubCollection, options)
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-/**
- * Write data to database
- * @param db
- * @param collectionName
- * @param docId
- * @param data
- * @param options
- */
-
-const startUpdating = (
-  db: Firestore,
-  collectionName: string,
-  docId: string,
-  data: object,
+  data: Record<string, any>,
   options: IImportOptions
-) => {
-  // Update date value
-  if (options.dates && options.dates.length > 0) {
-    options.dates.forEach((date) => {
-      if (data.hasOwnProperty(date)) {
-        // check type of the date
-        if (Array.isArray(data[date])) {
-          data[date] = data[date].map((d) => makeTime(d))
-        } else {
-          data[date] = makeTime(data[date])
-        }
-      }
-
-      // Check for nested date
-      if (date.indexOf('.') > -1) {
-        traverseObjects(data, (value) => {
-          if (!value.hasOwnProperty('_seconds')) {
-            return null
-          }
-          return makeTime(value)
-        })
-      }
-    })
+): void => {
+  if (options.dates?.length) {
+    options.dates.forEach((path) =>
+      applyToPath(data, path.split('.'), (val) =>
+        Array.isArray(val) ? val.map((d) => makeTime(d) ?? d) : (makeTime(val) ?? val)
+      )
+    )
   }
 
   if (options.autoParseDates) {
     parseAndConvertDates(data)
   }
 
-  // reference key
   if (options.refs?.length) {
-    options.refs.forEach((ref) => {
-      if (data.hasOwnProperty(ref)) {
-        // check type of the reference
-        if (Array.isArray(data[ref])) {
-          data[ref] = data[ref].map((dataRef) => db.doc(dataRef))
-        } else {
-          data[ref] = db.doc(data[ref])
-        }
-      } else if (data.hasOwnProperty(ref.split('.')[0])) {
-        // Nested object ref let test each element
-        ref.split('.').reduce((prev, curr, index) => {
-          // check if the data is array of object
-          if (Array.isArray(prev)) {
-            // If we have array at root we test each element
-            return prev.reduce((acc, c) => {
-              if (typeof c[curr] === 'string') {
-                // if is string transform them in refs
-                c[curr] = db.doc(c[curr])
-              } else if (typeof c[curr] === 'object') {
-                // if is object return the object for next callback of reduce
-                return (acc = c[curr])
-              } else {
-                // if it's undefined beacause the properties not exist return the object
-                return acc
-              }
-            }, {})
-          } else {
-            if (
-              Array.isArray(prev[curr]) &&
-              ref.split('.').length === index + 1
-            ) {
-              // If we have array at seconds transform them in refs
-              prev[curr] = prev[curr].map((e) => db.doc(e))
-            } else if (ref.split('.').length === index + 1 && prev[curr]) {
-              // Transform in ref if we are at last ref
-              return (prev[curr] = db.doc(prev[curr]))
-            } else {
-              // If pre[curr] is undefined, set it to null
-              return (prev[curr] = prev[curr] || null)
-            }
-          }
-        }, data)
-      }
-    })
+    options.refs.forEach((path) =>
+      applyToPath(data, path.split('.'), (val) => {
+        if (Array.isArray(val)) return val.map((r) => db.doc(r))
+        if (typeof val === 'string') return db.doc(val)
+        return val
+      })
+    )
   }
 
-  // Enter geo value
-  if (options.geos && options.geos.length > 0) {
-    options.geos.forEach((geo) => {
-      if (data.hasOwnProperty(geo)) {
-        // array of geo locations
-        if (Array.isArray(data[geo])) {
-          data[geo] = data[geo].map((geoValues) => makeGeoPoint(geoValues))
-        } else {
-          data[geo] = makeGeoPoint(data[geo])
-        }
-      }
-
-      if (geo.indexOf('.') > -1) {
-        traverseObjects(data, (value) => {
-          if (!value.hasOwnProperty('_latitude')) {
-            return null
-          }
-          return makeGeoPoint(value)
-        })
-      }
-    })
+  if (options.geos?.length) {
+    options.geos.forEach((path) =>
+      applyToPath(data, path.split('.'), (val) =>
+        Array.isArray(val) ? val.map((g) => makeGeoPoint(g) ?? g) : (makeGeoPoint(val) ?? val)
+      )
+    )
   }
 
   if (options.autoParseGeos) {
     parseAndConvertGeos(data)
   }
+}
 
-  return new Promise((resolve, reject) => {
-    db.collection(collectionName)
-      .doc(docId)
-      .set(data)
-      .then(() => {
-        options?.showLogs &&
-          console.log(`${docId} was successfully added to firestore!`)
-        resolve({
-          status: true,
-          message: `${docId} was successfully added to firestore!`,
-        })
-      })
-      .catch((error) => {
-        console.log(error)
-        reject({
-          status: false,
-          message: error.message,
-        })
-      })
-  })
+const collectWrites = (
+  db: Firestore,
+  dataObj: Record<string, any>,
+  options: IImportOptions,
+  writes: WriteOp[]
+): void => {
+  for (const collectionName of Object.keys(dataObj)) {
+    const collectionData = dataObj[collectionName]
+    const isArr = Array.isArray(collectionData)
+
+    const processDoc = (docId: string, docValue: any): void => {
+      const rawData = { ...docValue }
+      const subCollections = rawData.subCollection as Record<string, any> | undefined
+      delete rawData.subCollection
+
+      prepareData(db, rawData, options)
+      writes.push({ ref: db.collection(collectionName).doc(docId), data: rawData })
+
+      if (subCollections) {
+        if (isArr) {
+          for (const subIndex of Object.keys(subCollections)) {
+            collectWrites(
+              db,
+              { [`${collectionName}/${docId}/${subIndex}`]: subCollections[subIndex] },
+              options,
+              writes
+            )
+          }
+        } else {
+          collectWrites(db, subCollections, options, writes)
+        }
+      }
+    }
+
+    if (isArr) {
+      for (const docValue of collectionData) {
+        processDoc(uuidv1(), docValue)
+      }
+    } else {
+      for (const [docId, docValue] of Object.entries(collectionData)) {
+        processDoc(docId, docValue)
+      }
+    }
+  }
+}
+
+const updateCollection = async (
+  db: Firestore,
+  dataObj: Record<string, any>,
+  options: IImportOptions
+): Promise<void> => {
+  if (options.clearCollection) {
+    for (const collectionName of Object.keys(dataObj)) {
+      await db.recursiveDelete(db.collection(collectionName))
+    }
+  }
+
+  const writes: WriteOp[] = []
+  collectWrites(db, dataObj, options, writes)
+
+  for (let i = 0; i < writes.length; i += BATCH_SIZE) {
+    const batch = db.batch()
+    writes.slice(i, i + BATCH_SIZE).forEach(({ ref, data }) => batch.set(ref, data))
+    await batch.commit()
+    if (options.showLogs) {
+      const committed = Math.min(BATCH_SIZE, writes.length - i)
+      console.log(`Committed ${committed} documents (${i + committed}/${writes.length} total)`)
+    }
+  }
+}
+
+export const restoreService = async (
+  db: Firestore,
+  fileName: string | object,
+  options: IImportOptions
+): Promise<{ status: boolean; message: string }> => {
+  try {
+    const dataObj: Record<string, any> =
+      typeof fileName === 'object'
+        ? (fileName as Record<string, any>)
+        : JSON.parse(await fs.promises.readFile(fileName as string, 'utf8'))
+
+    await updateCollection(db, dataObj, options)
+    return { status: true, message: 'Collection successfully imported!' }
+  } catch (error) {
+    throw { status: false, message: (error as Error).message }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,33 +32,33 @@ export const initializeFirebaseApp = (
   name = '[DEFAULT]',
   options: IInitializeAppOptions = {}
 ): Firestore => {
-  const apps = getApps()
-  if (apps.length === 0 || (apps.length > 0 && apps[0].name !== name)) {
-    // if serviceAccount is passed, initialize app with serviceAccount
-    let app: App
-    if (serviceAccount) {
-      app = initializeApp(
-        {
-          credential: cert(serviceAccount),
-          databaseURL: serviceAccount['databaseURL'],
-        },
-        name
-      )
-    } else {
-      app = initializeApp(undefined, name)
-    }
+  const existingApp = getApps().find((a) => a.name === name)
 
-    const firestore = getFirestore(app)
-
-    firestore.settings({
-      timestampsInSnapshots: true,
-      ...options.firestore,
-    })
-  } else {
-    console.warn(`Firebase App exist. Return default firestore instance`)
+  if (existingApp) {
+    console.warn(`Firebase App "${name}" already exists. Returning existing Firestore instance.`)
+    return getFirestore(existingApp)
   }
 
-  return getFirestore(apps[0])
+  let app: App
+  if (serviceAccount) {
+    app = initializeApp(
+      {
+        credential: cert(serviceAccount),
+        databaseURL: serviceAccount['databaseURL'],
+      },
+      name
+    )
+  } else {
+    app = initializeApp(undefined, name)
+  }
+
+  const firestore = getFirestore(app)
+  firestore.settings({
+    timestampsInSnapshots: true,
+    ...options.firestore,
+  })
+
+  return firestore
 }
 
 /**

--- a/test/parses.spec.ts
+++ b/test/parses.spec.ts
@@ -1,4 +1,4 @@
-import { parseAndConvertDates, parseAndConvertGeos } from '../dist/helper'
+import { applyToPath, parseAndConvertDates, parseAndConvertGeos } from '../dist/helper'
 import { GeoPoint, Timestamp } from 'firebase-admin/firestore'
 
 describe('parse helpers', () => {
@@ -140,5 +140,59 @@ describe('parse helpers', () => {
     parseAndConvertGeos(data)
     expect(data.arr[0].obj.location).to.be.an.instanceOf(GeoPoint)
     expect(data.arr[1].obj.location).to.be.an.instanceOf(GeoPoint)
+  })
+
+  it('applies path conversion through nested objects', async () => {
+    const data = {
+      profile: {
+        createdAt: '2026-07-13',
+      },
+    }
+
+    applyToPath(data, ['profile', 'createdAt'], (value) => `${value}T00:00:00.000Z`)
+
+    expect(data.profile.createdAt).to.equal('2026-07-13T00:00:00.000Z')
+  })
+
+  it('applies path conversion through arrays of objects', async () => {
+    const data = {
+      users: [
+        { profile: { createdAt: '2026-07-13' } },
+        { profile: { createdAt: '2026-07-14' } },
+      ],
+    }
+
+    applyToPath(data, ['users', 'profile', 'createdAt'], (value) => `${value}T00:00:00.000Z`)
+
+    expect(data.users[0].profile.createdAt).to.equal('2026-07-13T00:00:00.000Z')
+    expect(data.users[1].profile.createdAt).to.equal('2026-07-14T00:00:00.000Z')
+  })
+
+  it('applies path conversion through arrays containing primitives', async () => {
+    const data = {
+      users: [
+        { profile: { createdAt: '2026-07-13' } },
+        'not-an-object',
+        { profile: { createdAt: '2026-07-14' } },
+      ],
+    }
+
+    applyToPath(data, ['users', 'profile', 'createdAt'], (value) => `${value}T00:00:00.000Z`)
+
+    expect(data.users[0].profile.createdAt).to.equal('2026-07-13T00:00:00.000Z')
+    expect(data.users[1]).to.equal('not-an-object')
+    expect(data.users[2].profile.createdAt).to.equal('2026-07-14T00:00:00.000Z')
+  })
+
+  it('leaves data unchanged when path does not exist', async () => {
+    const data = {
+      profile: {
+        createdAt: '2026-07-13',
+      },
+    }
+
+    applyToPath(data, ['profile', 'missing'], (value) => `${value}T00:00:00.000Z`)
+
+    expect(data.profile.createdAt).to.equal('2026-07-13')
   })
 })

--- a/test/parses.spec.ts
+++ b/test/parses.spec.ts
@@ -1,5 +1,5 @@
 import { parseAndConvertDates, parseAndConvertGeos } from '../dist/helper'
-import { GeoPoint } from 'firebase-admin/firestore'
+import { GeoPoint, Timestamp } from 'firebase-admin/firestore'
 
 describe('parse helpers', () => {
   it('Test auto parse dates option - simple', async () => {
@@ -10,7 +10,7 @@ describe('parse helpers', () => {
       },
     }
     parseAndConvertDates(data)
-    expect(data.date).to.be.an.instanceOf(Date)
+    expect(data.date).to.be.an.instanceOf(Timestamp)
   })
 
   it('Test auto parse dates option - nested', async () => {
@@ -29,8 +29,8 @@ describe('parse helpers', () => {
       },
     }
     parseAndConvertDates(data)
-    expect(data.date).to.be.an.instanceOf(Date)
-    expect(data.obj.anotherObj.date).to.be.an.instanceOf(Date)
+    expect(data.date).to.be.an.instanceOf(Timestamp)
+    expect(data.obj.anotherObj.date).to.be.an.instanceOf(Timestamp)
   })
 
   it('Test auto parse dates option - nested arrays', async () => {
@@ -43,7 +43,7 @@ describe('parse helpers', () => {
       ],
     }
     parseAndConvertDates(data)
-    expect(data.arr[0]).to.be.an.instanceOf(Date)
+    expect(data.arr[0]).to.be.an.instanceOf(Timestamp)
   })
 
   it('Test auto parse dates option - nested array objects', async () => {
@@ -68,8 +68,8 @@ describe('parse helpers', () => {
       ],
     }
     parseAndConvertDates(data)
-    expect(data.arr[0].obj.date).to.be.an.instanceOf(Date)
-    expect(data.arr[1].obj.date).to.be.an.instanceOf(Date)
+    expect(data.arr[0].obj.date).to.be.an.instanceOf(Timestamp)
+    expect(data.arr[1].obj.date).to.be.an.instanceOf(Timestamp)
   })
 
   it('Test auto parse geos option - simple', async () => {


### PR DESCRIPTION
## Summary

This PR fixes eight long-standing issues and bumps the version to **1.7.0**.

---

## Bug Fixes

### #136 — Timestamps lose nanosecond precision on restore

`makeTime` was returning a JavaScript `Date`, which only has millisecond precision. Any nanoseconds stored in Firestore were silently dropped on restore.

**Fix:** `makeTime` now returns `Firestore.Timestamp(seconds, nanoseconds)`, which is also the native type the SDK stores and returns. The `_nanoseconds` field is fully preserved.

> **Note:** `parseAndConvertDates` and the `dates` option now produce `Timestamp` values instead of `Date`. This is consistent with what `backup()` returns when reading from Firestore.

---

### #50 — Dates inside arrays of objects are not converted

Given a structure like:
```json
{ "notifications": [{ "date": { "_seconds": 1534046400, "_nanoseconds": 0 } }] }
```
Using `dates: ['notifications.date']` had no effect — the dot-path handler used `traverseObjects` which did not navigate into array elements correctly for the `dates` option.

**Fix:** Replaced all ad-hoc path handling (dot-split + `traverseObjects`) with a single `applyToPath` helper that recursively walks any combination of nested objects and arrays.

---

### #83 — GeoPoints inside arrays of maps are imported as plain numbers

Same root cause as #50. When a field like `geos: ['locations']` pointed to an array of objects containing `_latitude`/`_longitude`, the code only handled arrays of direct GeoPoints, not arrays of objects.

**Fix:** Same `applyToPath` approach. Arrays at any nesting depth are automatically iterated.

---

### Refs in arrays of objects (same root cause as #50 / #83)

The nested ref resolution used a complex `reduce` chain that mutated intermediate objects to `null` when a path segment was missing, and did not handle arrays of objects uniformly.

**Fix:** Replaced with `applyToPath`. Non-existent paths are now silently skipped (no mutation to `null`).

---

### `makeGeoPoint` returning `null` for coordinates equal to `0`

The guard `if (!geoValues._latitude || !geoValues._longitude)` treated `0` as falsy, so a GeoPoint at latitude or longitude `0` would be discarded.

**Fix:** Changed to `if (geoValues?._latitude == null || geoValues?._longitude == null)`.

---

### #153 — Only [DEFAULT] firebase app is recognized

`initializeFirebaseApp` had two bugs:
1. The existence check `apps[0].name !== name` only looked at the first initialized app — if two apps were initialized in a different order, the check would always fail and try to re-initialize.
2. The final `return getFirestore(apps[0])` always returned the Firestore instance of the **first** app, regardless of which `name` was requested.

**Fix:** Replaced the index-based lookup with `getApps().find((a) => a.name === name)`. If the app already exists, return its Firestore directly. Otherwise initialize and return the new app's Firestore.

---

## New Features

### #18 — Batch writes on restore

Previously, `restoreService` called `db.collection().doc().set()` sequentially for every document — one network round-trip per document. On a collection with thousands of documents this was both slow and unnecessary.

**Fix:** All write operations are now collected first (synchronously, via `collectWrites`), then committed in batches of 500 using `db.batch()`. This matches Firestore's maximum batch size and reduces round-trips by up to 500×.

---

### #19 — `clearCollection` option: delete before restore

Without this option, restoring to an existing collection only overwrites matching document IDs — documents that exist in Firestore but not in the backup file are left untouched.

**New option:**
```ts
restore(db, 'backup.json', { clearCollection: true })
```
When set, each top-level collection in the backup file is deleted (recursively, including subcollections) via `db.recursiveDelete()` before the restore begins.

---

### #103 — `includeSubcollections` export option

Fetching subcollections requires one extra `listCollections()` call per document, which adds significant latency on large datasets. Many users do not need subcollections in their export.

**New option:**
```ts
backup(db, 'users', { includeSubcollections: false })
```
Defaults to `true` (existing behaviour unchanged).

---

### #121 — `showLogs` now works during export

Previously `showLogs: true` only printed output during restore. Export functions (`backup`, `backupFromDoc`, `backups`) ran silently regardless.

**Fix:** Added `showLogs` to `IExportOptions`. When enabled:
- `backups()` logs the list of collections before starting
- `backup()` logs the document count per collection after completing it
- `backupFromDoc()` logs the document and collection name after completing

---

## Internal changes

- `restoreService` rewritten from the Promise constructor pattern to `async/await` with `fs.promises.readFile`
- `startUpdating` removed; logic split into `prepareData` (pure data transformation) and batch commits in `updateCollection`
- `collectWrites` replaces the recursive async loop — subcollection paths are resolved synchronously before any write is committed

## Test plan

- [x] `pnpm typecheck` — no errors
- [x] `pnpm build` — ESM + CJS output generated cleanly
- [x] `vitest run test/parses.spec.ts` — 8/8 unit tests passing (updated `instanceOf(Date)` → `instanceOf(Timestamp)`)
- [ ] Integration tests (`firestore.spec.ts`) require a live Firebase project with credentials — please run against the QA project before merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to clear target collections before restoring data.
  * Added an option to exclude subcollections during exports.
  * Added optional export/import logging (`showLogs`) for progress visibility.
* **Bug Fixes**
  * Preserved timestamp nanosecond precision during restores.
  * Correctly handled GeoPoints with zero coordinates and missing lat/long.
  * Improved conversion of dates, GeoPoints, and references nested inside arrays/objects.
* **Performance & Polish**
  * Faster restore via batched writes.
  * Improved nested subcollection handling during import and export.
  * Updated to version 1.7.0.
* **Tests**
  * Updated date parsing expectations to use Firestore `Timestamp`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->