### PR TITLE
feat: add includeSubcollections and showLogs options to export (#103, #121)

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -20,6 +20,10 @@ export const getAllCollectionsService = async <T>(
     snap.forEach((collection) => paths.push(collection.path))
   }
 
+  if (options?.showLogs) {
+    console.log(`Starting backup of ${paths.length} collection(s): ${paths.join(', ')}`)
+  }
+
   // fetch in parallel
   const promises: Promise<T>[] = paths.map((path) =>
     backupService<T>(db, path, options)
@@ -80,7 +84,7 @@ export const backupFromDocService = async <T>(
         }
       }
 
-      if (subCollections.length > 0) {
+      if (subCollections.length > 0 && options?.includeSubcollections !== false) {
         data[collectionName][doc.id]['subCollection'] = {}
 
         for (const subCol of subCollections) {
@@ -96,6 +100,10 @@ export const backupFromDocService = async <T>(
           }
         }
       }
+    }
+
+    if (options?.showLogs) {
+      console.log(`Backed up document "${documentName}" from "${collectionName}"`)
     }
 
     return data as T
@@ -144,7 +152,7 @@ export const backUpDocRef = async <T>(
     }
   }
 
-  if (subCollections.length > 0) {
+  if (subCollections.length > 0 && options?.includeSubcollections !== false) {
     data['subCollection'] = {}
     const subColOptions = { ...options }
     if (subColOptions?.queryCollection) {
@@ -205,6 +213,10 @@ export const backupService = async <T>(
     promiseValues.forEach((dataMap) => {
       data[collectionName] = Object.assign(data[collectionName], dataMap)
     })
+
+    if (options?.showLogs) {
+      console.log(`Backed up ${docs.length} document(s) from "${collectionName}"`)
+    }
 
     return data as T
   } catch (error) {

--- a/src/export.ts
+++ b/src/export.ts
@@ -55,7 +55,6 @@ export const backupFromDocService = async <T>(
     const docs = [document]
 
     for (const doc of docs) {
-      const subCollections = await doc.ref.listCollections()
       data[collectionName][doc.id] = doc.data() || {}
 
       if (options?.refs) {
@@ -84,19 +83,22 @@ export const backupFromDocService = async <T>(
         }
       }
 
-      if (subCollections.length > 0 && options?.includeSubcollections !== false) {
-        data[collectionName][doc.id]['subCollection'] = {}
+      if (options?.includeSubcollections !== false) {
+        const subCollections = await doc.ref.listCollections()
+        if (subCollections.length > 0) {
+          data[collectionName][doc.id]['subCollection'] = {}
 
-        for (const subCol of subCollections) {
-          const subColData = await backupService<object>(
-            db,
-            `${collectionName}/${documentName}/${subCol.id}`,
-            options
-          )
+          for (const subCol of subCollections) {
+            const subColData = await backupService<object>(
+              db,
+              `${collectionName}/${documentName}/${subCol.id}`,
+              options
+            )
 
-          data[collectionName][doc.id]['subCollection'] = {
-            ...data[collectionName][doc.id]['subCollection'],
-            ...subColData,
+            data[collectionName][doc.id]['subCollection'] = {
+              ...data[collectionName][doc.id]['subCollection'],
+              ...subColData,
+            }
           }
         }
       }
@@ -126,7 +128,6 @@ export const backUpDocRef = async <T>(
   collectionPath: String,
   options?: IExportOptions
 ): Promise<T> => {
-  const subCollections = await doc.ref.listCollections()
   let data = Object.assign({}, doc.data())
 
   if (options?.refs) {
@@ -152,25 +153,29 @@ export const backUpDocRef = async <T>(
     }
   }
 
-  if (subCollections.length > 0 && options?.includeSubcollections !== false) {
-    data['subCollection'] = {}
-    const subColOptions = { ...options }
-    if (subColOptions?.queryCollection) {
-      delete subColOptions.queryCollection
-    }
-    for (const subCol of subCollections) {
-      const subColData = await backupService<object>(
-        db,
-        `${collectionPath}/${doc.id}/${subCol.id}`,
-        subColOptions
-      )
+  if (options?.includeSubcollections !== false) {
+    const subCollections = await doc.ref.listCollections()
+    if (subCollections.length > 0) {
+      data['subCollection'] = {}
+      const subColOptions = { ...options }
+      if (subColOptions?.queryCollection) {
+        delete subColOptions.queryCollection
+      }
+      for (const subCol of subCollections) {
+        const subColData = await backupService<object>(
+          db,
+          `${collectionPath}/${doc.id}/${subCol.id}`,
+          subColOptions
+        )
 
-      data['subCollection'] = {
-        ...data['subCollection'],
-        ...subColData,
+        data['subCollection'] = {
+          ...data['subCollection'],
+          ...subColData,
+        }
       }
     }
   }
+
   let tR: { [key: string]: any } = {}
   tR[doc.id] = data
   return tR as T

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -12,6 +12,8 @@ export interface IImportOptions {
 export interface IExportOptions {
   docsFromEachCollection?: number
   refs?: string[]
+  includeSubcollections?: boolean
+  showLogs?: boolean
   queryCollection?: (
     ref: FirebaseFirestore.CollectionReference
   ) => Promise<FirebaseFirestore.QuerySnapshot>


### PR DESCRIPTION
## Changes

### `includeSubcollections` option (#103)

Set to `false` to skip subcollection traversal during backup. Useful for large datasets where subcollections aren't needed.

```ts
// skip subcollections — faster export
const data = await backup(db, 'users', { includeSubcollections: false })
```

Default is `true`, so existing code is unaffected.

### `showLogs` option for export (#121)

`showLogs` was already supported on import (`restore`). This PR adds it to the export side: `backup`, `backups`, and `backupFromDoc` now log progress when `showLogs: true`.

```ts
const data = await backups(db, [], { showLogs: true })
// Starting backup of 3 collection(s): users, accounts, sessions
// Backed up 138 document(s) from "users"
// ...
```

## Files changed

- `src/helper.ts` — added `includeSubcollections?: boolean` and `showLogs?: boolean` to `IExportOptions`
- `src/export.ts` — added log statements and subcollection guards

Closes #103, #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include or exclude subcollections during exports.
  * Added optional export progress logging, including backup completion and document counts per collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->