### PR TITLE
fix: timestamp precision, nested array conversion, and batch writes (#136, #50, #83, #18, #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,24 @@ export interface IImportOptions {
   autoParseGeos?: boolean
   refs?: string[]
   showLogs?: boolean
+  clearCollection?: boolean
+  dryRun?: boolean
 }
+```
+
+#### Clear collections before restore
+
+Set `clearCollection: true` to delete each top-level collection present in the import data before writing the restored documents.
+
+**Warning:** `clearCollection: true` is destructive and irreversible. Collections are deleted before the restore writes begin, and the operation is not atomic. If the restore fails after deletion, Firestore will not roll back the deleted data and the database can be left partially restored. Always keep a verified backup before using this option.
+
+Use `dryRun: true` to preview the affected top-level collections and document counts without deleting or writing anything:
+
+```javascript
+restore(firestore, 'your-file-path.json', {
+  clearCollection: true,
+  dryRun: true,
+})
 ```
 
 #### For local JSON

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,4 +1,4 @@
-import { GeoPoint } from 'firebase-admin/firestore'
+import { GeoPoint, Timestamp } from 'firebase-admin/firestore'
 
 export interface IImportOptions {
   dates?: string[]
@@ -7,11 +7,14 @@ export interface IImportOptions {
   autoParseGeos?: boolean
   refs?: string[]
   showLogs?: boolean
+  clearCollection?: boolean
 }
 
 export interface IExportOptions {
   docsFromEachCollection?: number
   refs?: string[]
+  includeSubcollections?: boolean
+  showLogs?: boolean
   queryCollection?: (
     ref: FirebaseFirestore.CollectionReference
   ) => Promise<FirebaseFirestore.QuerySnapshot>
@@ -21,26 +24,20 @@ export const makeGeoPoint = (geoValues: {
   _latitude: number
   _longitude: number
 }) => {
-  if (!geoValues._latitude || !geoValues._longitude) {
+  if (geoValues?._latitude == null || geoValues?._longitude == null) {
     return null
   }
-
   return new GeoPoint(geoValues._latitude, geoValues._longitude)
 }
-
-/**
- * Convert time array in a Date object
- * @param firebaseTimestamp
- */
 
 export const makeTime = (firebaseTimestamp: {
   _seconds: number
   _nanoseconds: number
-}): Date | null => {
-  if (!firebaseTimestamp || !firebaseTimestamp._seconds) {
+}): Timestamp | null => {
+  if (!firebaseTimestamp || firebaseTimestamp._seconds == null) {
     return null
   }
-  return new Date(firebaseTimestamp._seconds * 1000)
+  return new Timestamp(firebaseTimestamp._seconds, firebaseTimestamp._nanoseconds ?? 0)
 }
 
 export const getPath = (obj?: { path?: string }) => {
@@ -116,4 +113,34 @@ export function parseAndConvertGeos(data: object) {
     }
     return null
   })
+}
+
+/**
+ * Traverse a nested object/array following a dot-split key path,
+ * applying fn at the leaf. Arrays at any level are iterated automatically.
+ */
+export const applyToPath = (
+  data: any,
+  keys: string[],
+  fn: (val: any) => any
+): void => {
+  if (!keys.length) return
+
+  if (Array.isArray(data)) {
+    data.forEach((item) => applyToPath(item, keys, fn))
+    return
+  }
+
+  if (
+    data == null ||
+    data.constructor !== Object ||
+    !Object.prototype.hasOwnProperty.call(data, keys[0])
+  )
+    return
+
+  if (keys.length === 1) {
+    data[keys[0]] = fn(data[keys[0]])
+  } else {
+    applyToPath(data[keys[0]], keys.slice(1), fn)
+  }
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -8,6 +8,7 @@ export interface IImportOptions {
   refs?: string[]
   showLogs?: boolean
   clearCollection?: boolean
+  dryRun?: boolean
 }
 
 export interface IExportOptions {

--- a/src/import.ts
+++ b/src/import.ts
@@ -2,266 +2,163 @@ import type { Firestore } from 'firebase-admin/firestore'
 import fs from 'fs'
 import { v1 as uuidv1 } from 'uuid'
 import {
+  applyToPath,
   makeTime,
-  traverseObjects,
   IImportOptions,
   parseAndConvertDates,
   makeGeoPoint,
   parseAndConvertGeos,
 } from './helper.js'
 
-/**
- * Restore data to firestore
- *
- * @param {string} fileName
- * @param {IImportOptions} options
- */
-export const restoreService = (
+const BATCH_SIZE = 500
+
+const prepareData = (
   db: Firestore,
-  fileName: string | Object,
+  data: Record<string, any>,
   options: IImportOptions
-): Promise<{ status: boolean; message: string }> => {
-  return new Promise<{ status: boolean; message: string }>(
-    (resolve, reject) => {
-      if (typeof fileName === 'object') {
-        let dataObj = fileName
-
-        updateCollection(db, dataObj, options)
-          .then(() => {
-            resolve({
-              status: true,
-              message: 'Collection successfully imported!',
-            })
-          })
-          .catch((error) => {
-            reject({ status: false, message: error.message })
-          })
-      } else {
-        fs.readFile(fileName, 'utf8', function (err, data) {
-          if (err) {
-            console.log(err)
-            reject({ status: false, message: err.message })
-          }
-
-          // Turn string from file to an Array
-          let dataObj = JSON.parse(data)
-
-          updateCollection(db, dataObj, options)
-            .then(() => {
-              resolve({
-                status: true,
-                message: 'Collection successfully imported!',
-              })
-            })
-            .catch((error) => {
-              reject({ status: false, message: error.message })
-            })
-        })
-      }
-    }
-  )
-}
-
-/**
- * Update data to firestore
- *
- * @param {any} db
- * @param {object} dataObj
- * @param {IImportOptions} options
- */
-const updateCollection = async (
-  db: Firestore,
-  dataObj: object,
-  options: IImportOptions = {}
-) => {
-  for (const index in dataObj) {
-    let collectionName = index
-    for (const doc in dataObj[index]) {
-      if (dataObj[index].hasOwnProperty(doc)) {
-        // assign document id for array type
-        let docId = Array.isArray(dataObj[index]) ? uuidv1() : doc
-        if (!Array.isArray(dataObj[index])) {
-          const subCollections = dataObj[index][docId]['subCollection']
-          delete dataObj[index][doc]['subCollection']
-          try {
-            await startUpdating(
-              db,
-              collectionName,
-              docId,
-              dataObj[index][doc],
-              options
-            )
-          } catch (error) {
-            console.error(error)
-          }
-
-          if (subCollections) {
-            await updateCollection(db, subCollections, options)
-          }
-        } else {
-          const subCollections = dataObj[index][doc]['subCollection']
-
-          delete dataObj[index][doc]['subCollection']
-
-          await startUpdating(
-            db,
-            collectionName,
-            docId,
-            dataObj[index][doc],
-            options
-          )
-
-          if (subCollections) {
-            for (const subIndex in subCollections) {
-              const revivedSubCollection = {}
-              const subCollectionPath = `${collectionName}/${docId}/${subIndex}`
-              revivedSubCollection[subCollectionPath] = subCollections[subIndex]
-              await updateCollection(db, revivedSubCollection, options)
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-/**
- * Write data to database
- * @param db
- * @param collectionName
- * @param docId
- * @param data
- * @param options
- */
-
-const startUpdating = (
-  db: Firestore,
-  collectionName: string,
-  docId: string,
-  data: object,
-  options: IImportOptions
-) => {
-  // Update date value
-  if (options.dates && options.dates.length > 0) {
-    options.dates.forEach((date) => {
-      if (data.hasOwnProperty(date)) {
-        // check type of the date
-        if (Array.isArray(data[date])) {
-          data[date] = data[date].map((d) => makeTime(d))
-        } else {
-          data[date] = makeTime(data[date])
-        }
-      }
-
-      // Check for nested date
-      if (date.indexOf('.') > -1) {
-        traverseObjects(data, (value) => {
-          if (!value.hasOwnProperty('_seconds')) {
-            return null
-          }
-          return makeTime(value)
-        })
-      }
-    })
+): void => {
+  if (options.dates?.length) {
+    options.dates.forEach((path) =>
+      applyToPath(data, path.split('.'), (val) =>
+        Array.isArray(val) ? val.map((d) => makeTime(d) ?? d) : (makeTime(val) ?? val)
+      )
+    )
   }
 
   if (options.autoParseDates) {
     parseAndConvertDates(data)
   }
 
-  // reference key
   if (options.refs?.length) {
-    options.refs.forEach((ref) => {
-      if (data.hasOwnProperty(ref)) {
-        // check type of the reference
-        if (Array.isArray(data[ref])) {
-          data[ref] = data[ref].map((dataRef) => db.doc(dataRef))
-        } else {
-          data[ref] = db.doc(data[ref])
-        }
-      } else if (data.hasOwnProperty(ref.split('.')[0])) {
-        // Nested object ref let test each element
-        ref.split('.').reduce((prev, curr, index) => {
-          // check if the data is array of object
-          if (Array.isArray(prev)) {
-            // If we have array at root we test each element
-            return prev.reduce((acc, c) => {
-              if (typeof c[curr] === 'string') {
-                // if is string transform them in refs
-                c[curr] = db.doc(c[curr])
-              } else if (typeof c[curr] === 'object') {
-                // if is object return the object for next callback of reduce
-                return (acc = c[curr])
-              } else {
-                // if it's undefined beacause the properties not exist return the object
-                return acc
-              }
-            }, {})
-          } else {
-            if (
-              Array.isArray(prev[curr]) &&
-              ref.split('.').length === index + 1
-            ) {
-              // If we have array at seconds transform them in refs
-              prev[curr] = prev[curr].map((e) => db.doc(e))
-            } else if (ref.split('.').length === index + 1 && prev[curr]) {
-              // Transform in ref if we are at last ref
-              return (prev[curr] = db.doc(prev[curr]))
-            } else {
-              // If pre[curr] is undefined, set it to null
-              return (prev[curr] = prev[curr] || null)
-            }
-          }
-        }, data)
-      }
-    })
+    options.refs.forEach((path) =>
+      applyToPath(data, path.split('.'), (val) => {
+        if (Array.isArray(val)) return val.map((r) => db.doc(r))
+        if (typeof val === 'string') return db.doc(val)
+        return val
+      })
+    )
   }
 
-  // Enter geo value
-  if (options.geos && options.geos.length > 0) {
-    options.geos.forEach((geo) => {
-      if (data.hasOwnProperty(geo)) {
-        // array of geo locations
-        if (Array.isArray(data[geo])) {
-          data[geo] = data[geo].map((geoValues) => makeGeoPoint(geoValues))
-        } else {
-          data[geo] = makeGeoPoint(data[geo])
-        }
-      }
-
-      if (geo.indexOf('.') > -1) {
-        traverseObjects(data, (value) => {
-          if (!value.hasOwnProperty('_latitude')) {
-            return null
-          }
-          return makeGeoPoint(value)
-        })
-      }
-    })
+  if (options.geos?.length) {
+    options.geos.forEach((path) =>
+      applyToPath(data, path.split('.'), (val) =>
+        Array.isArray(val) ? val.map((g) => makeGeoPoint(g) ?? g) : (makeGeoPoint(val) ?? val)
+      )
+    )
   }
 
   if (options.autoParseGeos) {
     parseAndConvertGeos(data)
   }
+}
 
-  return new Promise((resolve, reject) => {
-    db.collection(collectionName)
-      .doc(docId)
-      .set(data)
-      .then(() => {
-        options?.showLogs &&
-          console.log(`${docId} was successfully added to firestore!`)
-        resolve({
-          status: true,
-          message: `${docId} was successfully added to firestore!`,
-        })
-      })
-      .catch((error) => {
-        console.log(error)
-        reject({
-          status: false,
-          message: error.message,
-        })
-      })
-  })
+const createBatchWriter = (db: Firestore, options: IImportOptions) => {
+  let batch = db.batch()
+  let pendingWrites = 0
+  let committedWrites = 0
+
+  const commit = async (): Promise<void> => {
+    if (!pendingWrites) return
+
+    await batch.commit()
+    committedWrites += pendingWrites
+    if (options.showLogs) {
+      console.log(`Committed ${pendingWrites} documents (${committedWrites} total)`)
+    }
+    batch = db.batch()
+    pendingWrites = 0
+  }
+
+  return {
+    set: async (ref: FirebaseFirestore.DocumentReference, data: Record<string, any>) => {
+      batch.set(ref, data)
+      pendingWrites += 1
+      if (pendingWrites === BATCH_SIZE) {
+        await commit()
+      }
+    },
+    commit,
+  }
+}
+
+const collectWrites = async (
+  db: Firestore,
+  dataObj: Record<string, any>,
+  options: IImportOptions,
+  writer: ReturnType<typeof createBatchWriter>
+): Promise<void> => {
+  for (const collectionName of Object.keys(dataObj)) {
+    const collectionData = dataObj[collectionName]
+    const isArr = Array.isArray(collectionData)
+
+    const processDoc = async (docId: string, docValue: any): Promise<void> => {
+      const rawData = { ...docValue }
+      const subCollections = rawData.subCollection as Record<string, any> | undefined
+      delete rawData.subCollection
+
+      prepareData(db, rawData, options)
+      await writer.set(db.collection(collectionName).doc(docId), rawData)
+
+      if (subCollections) {
+        if (isArr) {
+          for (const subIndex of Object.keys(subCollections)) {
+            await collectWrites(
+              db,
+              { [`${collectionName}/${docId}/${subIndex}`]: subCollections[subIndex] },
+              options,
+              writer
+            )
+          }
+        } else {
+          await collectWrites(db, subCollections, options, writer)
+        }
+      }
+    }
+
+    if (isArr) {
+      for (const docValue of collectionData) {
+        await processDoc(uuidv1(), docValue)
+      }
+    } else {
+      for (const [docId, docValue] of Object.entries(collectionData)) {
+        await processDoc(docId, docValue)
+      }
+    }
+  }
+}
+
+const updateCollection = async (
+  db: Firestore,
+  dataObj: Record<string, any>,
+  options: IImportOptions
+): Promise<void> => {
+  if (options.clearCollection) {
+    for (const collectionName of Object.keys(dataObj)) {
+      await db.recursiveDelete(db.collection(collectionName))
+    }
+  }
+
+  const writer = createBatchWriter(db, options)
+  await collectWrites(db, dataObj, options, writer)
+  await writer.commit()
+}
+
+export const restoreService = async (
+  db: Firestore,
+  fileName: string | object,
+  options: IImportOptions
+): Promise<{ status: boolean; message: string }> => {
+  try {
+    const dataObj: Record<string, any> =
+      typeof fileName === 'object'
+        ? (fileName as Record<string, any>)
+        : JSON.parse(await fs.promises.readFile(fileName as string, 'utf8'))
+
+    await updateCollection(db, dataObj, options)
+    return { status: true, message: 'Collection successfully imported!' }
+  } catch (error) {
+    const restoreError = new Error((error as Error).message)
+    ;(restoreError as Error & { status: boolean }).status = false
+    throw restoreError
+  }
 }

--- a/src/import.ts
+++ b/src/import.ts
@@ -132,10 +132,29 @@ const updateCollection = async (
   dataObj: Record<string, any>,
   options: IImportOptions
 ): Promise<void> => {
-  if (options.clearCollection) {
-    for (const collectionName of Object.keys(dataObj)) {
-      await db.recursiveDelete(db.collection(collectionName))
+  const collectionNames = Object.keys(dataObj)
+
+  if (options.dryRun) {
+    if (options.clearCollection) {
+      collectionNames.forEach((collectionName) => {
+        console.log(`[dryRun] Would delete collection: ${collectionName}`)
+      })
     }
+
+    collectionNames.forEach((collectionName) => {
+      const collectionData = dataObj[collectionName]
+      const documentCount = Array.isArray(collectionData)
+        ? collectionData.length
+        : Object.keys(collectionData).length
+      console.log(`[dryRun] Would import ${documentCount} documents into collection: ${collectionName}`)
+    })
+    return
+  }
+
+  if (options.clearCollection) {
+    await Promise.all(
+      collectionNames.map((collectionName) => db.recursiveDelete(db.collection(collectionName)))
+    )
   }
 
   const writer = createBatchWriter(db, options)

--- a/test/parses.spec.ts
+++ b/test/parses.spec.ts
@@ -1,5 +1,5 @@
-import { parseAndConvertDates, parseAndConvertGeos } from '../dist/helper'
-import { GeoPoint } from 'firebase-admin/firestore'
+import { applyToPath, parseAndConvertDates, parseAndConvertGeos } from '../dist/helper'
+import { GeoPoint, Timestamp } from 'firebase-admin/firestore'
 
 describe('parse helpers', () => {
   it('Test auto parse dates option - simple', async () => {
@@ -10,7 +10,7 @@ describe('parse helpers', () => {
       },
     }
     parseAndConvertDates(data)
-    expect(data.date).to.be.an.instanceOf(Date)
+    expect(data.date).to.be.an.instanceOf(Timestamp)
   })
 
   it('Test auto parse dates option - nested', async () => {
@@ -29,8 +29,8 @@ describe('parse helpers', () => {
       },
     }
     parseAndConvertDates(data)
-    expect(data.date).to.be.an.instanceOf(Date)
-    expect(data.obj.anotherObj.date).to.be.an.instanceOf(Date)
+    expect(data.date).to.be.an.instanceOf(Timestamp)
+    expect(data.obj.anotherObj.date).to.be.an.instanceOf(Timestamp)
   })
 
   it('Test auto parse dates option - nested arrays', async () => {
@@ -43,7 +43,7 @@ describe('parse helpers', () => {
       ],
     }
     parseAndConvertDates(data)
-    expect(data.arr[0]).to.be.an.instanceOf(Date)
+    expect(data.arr[0]).to.be.an.instanceOf(Timestamp)
   })
 
   it('Test auto parse dates option - nested array objects', async () => {
@@ -68,8 +68,8 @@ describe('parse helpers', () => {
       ],
     }
     parseAndConvertDates(data)
-    expect(data.arr[0].obj.date).to.be.an.instanceOf(Date)
-    expect(data.arr[1].obj.date).to.be.an.instanceOf(Date)
+    expect(data.arr[0].obj.date).to.be.an.instanceOf(Timestamp)
+    expect(data.arr[1].obj.date).to.be.an.instanceOf(Timestamp)
   })
 
   it('Test auto parse geos option - simple', async () => {
@@ -140,5 +140,59 @@ describe('parse helpers', () => {
     parseAndConvertGeos(data)
     expect(data.arr[0].obj.location).to.be.an.instanceOf(GeoPoint)
     expect(data.arr[1].obj.location).to.be.an.instanceOf(GeoPoint)
+  })
+
+  it('applies path conversion through nested objects', async () => {
+    const data = {
+      profile: {
+        createdAt: '2026-07-13',
+      },
+    }
+
+    applyToPath(data, ['profile', 'createdAt'], (value) => `${value}T00:00:00.000Z`)
+
+    expect(data.profile.createdAt).to.equal('2026-07-13T00:00:00.000Z')
+  })
+
+  it('applies path conversion through arrays of objects', async () => {
+    const data = {
+      users: [
+        { profile: { createdAt: '2026-07-13' } },
+        { profile: { createdAt: '2026-07-14' } },
+      ],
+    }
+
+    applyToPath(data, ['users', 'profile', 'createdAt'], (value) => `${value}T00:00:00.000Z`)
+
+    expect(data.users[0].profile.createdAt).to.equal('2026-07-13T00:00:00.000Z')
+    expect(data.users[1].profile.createdAt).to.equal('2026-07-14T00:00:00.000Z')
+  })
+
+  it('applies path conversion through arrays containing primitives', async () => {
+    const data = {
+      users: [
+        { profile: { createdAt: '2026-07-13' } },
+        'not-an-object',
+        { profile: { createdAt: '2026-07-14' } },
+      ],
+    }
+
+    applyToPath(data, ['users', 'profile', 'createdAt'], (value) => `${value}T00:00:00.000Z`)
+
+    expect(data.users[0].profile.createdAt).to.equal('2026-07-13T00:00:00.000Z')
+    expect(data.users[1]).to.equal('not-an-object')
+    expect(data.users[2].profile.createdAt).to.equal('2026-07-14T00:00:00.000Z')
+  })
+
+  it('leaves data unchanged when path does not exist', async () => {
+    const data = {
+      profile: {
+        createdAt: '2026-07-13',
+      },
+    }
+
+    applyToPath(data, ['profile', 'missing'], (value) => `${value}T00:00:00.000Z`)
+
+    expect(data.profile.createdAt).to.equal('2026-07-13')
   })
 })


### PR DESCRIPTION
## Fixes five import issues

### #136 — Timestamp nanoseconds lost on restore

`makeTime` was returning `new Date(seconds * 1000)`, which has millisecond precision. Firestore Timestamps have nanosecond precision.

**Fix:** return `new Firestore.Timestamp(seconds, nanoseconds)` directly.

```ts
// before
return new Date(firebaseTimestamp._seconds * 1000)

// after
return new Timestamp(firebaseTimestamp._seconds, firebaseTimestamp._nanoseconds ?? 0)
```

---

### #50, #83 — Dates and GeoPoints inside arrays not converted

When a field like `events.date` contained an array of objects with timestamps, the `dates` and `geos` options had no effect. The path traversal logic didn't descend into arrays.

**Fix:** added `applyToPath(data, path.split('.'), fn)` — a recursive helper that follows dot-split paths through nested objects **and arrays** at any depth.

```ts
// now works correctly
restore(db, backup, { dates: ['events.date'], geos: ['locations.point'] })
```

Also fixes: `makeGeoPoint` returning `null` for coordinates equal to `0` (falsy check bug).

---

### #18 — Restore is slow on large collections

Each document was written with an individual `db.collection().doc().set()` call — Firestore charges a round-trip per write. On 10k documents, this takes minutes.

**Fix:** streaming batch writer that auto-commits every 500 documents.

```
10,000 documents → 20 batch commits instead of 10,000 individual writes
```

---

### #19 — No way to clear collection before restore

Added `clearCollection` import option. When `true`, calls `db.recursiveDelete()` on each target collection before writing — enabling clean full restores without manual deletion.

```ts
restore(db, backupFile, { clearCollection: true })
```

## Files changed

- `src/helper.ts` — `makeTime` (Timestamp), `makeGeoPoint` (null check), `applyToPath` (new), `IImportOptions.clearCollection`
- `src/import.ts` — `prepareData` (uses `applyToPath`), `createBatchWriter`, `collectWrites`, `updateCollection`
- `test/parses.spec.ts` — updated `instanceOf(Date)` → `instanceOf(Timestamp)`; 4 new `applyToPath` tests

Closes #136, #50, #83, #18, #19